### PR TITLE
Add config support via binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@ By default, the following configuration is applied to the OpenTelemetry Java Age
 * `OTEL_JAVAAGENT_ENABLED=false`
 * `OTEL_METRICS_EXPORTER=none`
 
-When using a binding to configure the agent, properties are expected to be passed via a config tree format,
-where each key is the name of a file and the value its content. Keys can follow the environment variable format or the
-system property format, as described in the [project documentation](https://opentelemetry.io/docs/instrumentation/java/automatic/agent-config/).
+When using a [binding](https://paketo.io/docs/howto/configuration/#bindings), key/values map directly to OpenTelemetry Java agent configuration properties. Keys can follow the environment variable format or the system property format, as described in the [project documentation](https://opentelemetry.io/docs/instrumentation/java/automatic/agent-config/).
 
 ## Bindings
 
@@ -41,7 +39,7 @@ The buildpack optionally accepts the following bindings:
 
 | Key                   | Value   | Description                                                                                       |
 | --------------------- | ------- | ------------------------------------------------------------------------------------------------- |
-| `<otel-property-key>` | `<otel-property-value>` | Properties are expected to be passed via a config tree format, where each key is the name of a file and the value its content. That's the default behavior when passing key/value pairs via a Kubernetes Secret. Keys can follow the environment variable format or the system property format, as described in the [project documentation](https://opentelemetry.io/docs/instrumentation/java/automatic/agent-config/).  |
+| `<otel-property-key>` | `<otel-property-value>` | Binding key/values map directly to OpenTelemetry Java agent configuration properties. Keys can follow the environment variable format or the system property format, as described in the [project documentation](https://opentelemetry.io/docs/instrumentation/java/automatic/agent-config/). |
 
 ### Type: `dependency-mapping`
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Cloud Native Buildpacks - OpenTelemetry
+# Paketo Buildpack for OpenTelemetry
+
+## `gcr.io/paketo-buildpacks/opentelemetry`
 
 The OpenTelemetry Buildpack is a Cloud Native Buildpack that contributes and configures the OpenTelemetry Agent.
 
@@ -8,55 +10,44 @@ This buildpack will participate if all the following conditions are met
 
 * The `$BP_OPENTELEMETRY_ENABLED` is set to a truthy value (i.e. `true`, `t`, `1` ignoring case)
 
-The buildpack will do the following for Java applications:
+At build time, the buildpack will do the following for Java applications:
 
-* Contributes the OpenTelemetry Java agent to a layer and configures `$JAVA_TOOL_OPTIONS` to use it
+* Contributes the OpenTelemetry Java agent to a layer and configures `$JAVA_TOOL_OPTIONS` to use it.
+* By default, the agent is configured to be disabled (`OTEL_JAVAAGENT_ENABLED=false`).
+* By default, the metrics exporting feature of the agent is configured to be disabled (`OTEL_METRICS_EXPORTER=none`).
 
-## Testing
+At run time, the buildpack will do the following for Java applications:
 
-Given a Java application, you can package it by running the following command from the current folder.
-
-```shell
-pack build my-app \
-  --path <my_app_path> \
-  --buildpack paketo-buildpacks/java \
-  --buildpack . \
-  --builder paketobuildpacks/builder:base \
-  --verbose --trust-builder \
-  -e BP_JVM_VERSION=17 -e BP_OPENTELEMETRY_ENABLED=true
-```
-
-Next, run it as follows.
-
-```shell
-docker run --rm -p 8080:8080 my-app
-```
-
-Check the logs and verify the OpenTelemetry Agent was included.
-
-```log
-Picked up JAVA_TOOL_OPTIONS: -Djava.security.properties=/layers/paketo-buildpacks_bellsoft-liberica/java-security-properties/java-security.properties -XX:+ExitOnOutOfMemoryError -javaagent:/layers/paketo-buildpacks_opentelemetry/opentelemetry-java/opentelemetry-javaagent.jar -XX:ActiveProcessorCount=3 -XX:MaxDirectMemorySize=10M -Xmx3537385K -XX:MaxMetaspaceSize=98270K -XX:ReservedCodeCacheSize=240M -Xss1M -XX:+UnlockDiagnosticVMOptions -XX:NativeMemoryTracking=summary -XX:+PrintNMTStatistics
-
-[otel.javaagent 2022-06-28 21:16:29:365 +0000] [main] INFO io.opentelemetry.javaagent.tooling.VersionLogger - opentelemetry-javaagent - version: 1.15.0
-```
+* If a binding with `type` of `opentelemetry` exists, it uses the config tree from the binding to configure the OpenTelemetry Java agent. This is recommended when the configuration involves secrets of any kind.
 
 ## Usage
 
-Once you enable the OpenTelemetry buildpack, you can configure it at run-time via environment variables, as described in the [project documentation](https://opentelemetry.io/docs/instrumentation/java/automatic/agent-config/).
+Once you enable the OpenTelemetry buildpack at build-time, you can configure it at run-time via environment variables, as described in the [project documentation](https://opentelemetry.io/docs/instrumentation/java/automatic/agent-config/) or by passing configuration properties to the container via a binding.
+
+By default, the following configuration is applied to the OpenTelemetry Java Agent at run time.
+
+* `OTEL_JAVAAGENT_ENABLED=false`
+* `OTEL_METRICS_EXPORTER=none`
+
+When using a binding to configure the agent, properties are expected to be passed via a config tree format,
+where each key is the name of a file and the value its content. Keys can follow the environment variable format or the
+system property format, as described in the [project documentation](https://opentelemetry.io/docs/instrumentation/java/automatic/agent-config/).
 
 ## Bindings
 
 The buildpack optionally accepts the following bindings:
+
+### Type: `opentelemetry`
+
+| Key                   | Value   | Description                                                                                       |
+| --------------------- | ------- | ------------------------------------------------------------------------------------------------- |
+| `<otel-property-key>` | `<otel-property-value>` | Properties are expected to be passed via a config tree format, where each key is the name of a file and the value its content. That's the default behavior when passing key/value pairs via a Kubernetes Secret. Keys can follow the environment variable format or the system property format, as described in the [project documentation](https://opentelemetry.io/docs/instrumentation/java/automatic/agent-config/).  |
 
 ### Type: `dependency-mapping`
 
 | Key                   | Value   | Description                                                                                       |
 | --------------------- | ------- | ------------------------------------------------------------------------------------------------- |
 | `<dependency-digest>` | `<uri>` | If needed, the buildpack will fetch the dependency with digest `<dependency-digest>` from `<uri>` |
-
-## References
-
-This buildpack is based on the same structure used by [Paketo Buildpacks](https://paketo.io).
 
 ## License
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.7"
 
 [buildpack]
   description = "A Cloud Native Buildpack that contributes and configures the OpenTelemetry Agent"
-  homepage = "https://github.com/ThomasVitale/buildpacks-opentelemetry"
+  homepage = "https://github.com/paketo-buildpacks/opentelemetry"
   id = "paketo-buildpacks/opentelemetry"
   keywords = ["java", "opentelemetry"]
   name = "Paketo OpenTelemetry Buildpack"
@@ -11,7 +11,7 @@ api = "0.7"
 
   [[buildpack.licenses]]
     type = "Apache-2.0"
-    uri = "https://github.com/ThomasVitale/buildpacks-opentelemetry/blob/main/LICENSE"
+    uri = "https://github.com/paketo-buildpacks/opentelemetry/blob/main/LICENSE"
 
 [metadata]
   include-files = ["LICENSE", "NOTICE", "README.md", "bin/build", "bin/detect", "bin/main", "buildpack.toml"]

--- a/cmd/helper/main.go
+++ b/cmd/helper/main.go
@@ -17,16 +17,30 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
-	"github.com/paketo-buildpacks/libpak"
+	"github.com/buildpacks/libcnb"
 	"github.com/paketo-buildpacks/libpak/bard"
-	"github.com/paketo-buildpacks/opentelemetry/opentelemetry"
+	"github.com/paketo-buildpacks/libpak/sherpa"
+
+	"github.com/paketo-buildpacks/opentelemetry/helper"
 )
 
 func main() {
-	libpak.Main(
-		opentelemetry.Detect{},
-		opentelemetry.Build{Logger: bard.NewLogger(os.Stdout)},
-	)
+	sherpa.Execute(func() error {
+		var (
+			err error
+			p   = helper.Properties{Logger: bard.NewLogger(os.Stdout)}
+		)
+
+		p.Bindings, err = libcnb.NewBindingsFromEnvironment()
+		if err != nil {
+			return fmt.Errorf("unable to read bindings from environment\n%w", err)
+		}
+
+		return sherpa.Helpers(map[string]sherpa.ExecD{
+			"properties": p,
+		})
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ThomasVitale/buildpacks-opentelemetry
+module github.com/paketo-buildpacks/opentelemetry
 
 go 1.18
 

--- a/helper/init_test.go
+++ b/helper/init_test.go
@@ -14,19 +14,17 @@
  * limitations under the License.
  */
 
-package main
+package helper_test
 
 import (
-	"os"
+	"testing"
 
-	"github.com/paketo-buildpacks/libpak"
-	"github.com/paketo-buildpacks/libpak/bard"
-	"github.com/paketo-buildpacks/opentelemetry/opentelemetry"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
 )
 
-func main() {
-	libpak.Main(
-		opentelemetry.Detect{},
-		opentelemetry.Build{Logger: bard.NewLogger(os.Stdout)},
-	)
+func TestUnit(t *testing.T) {
+	suite := spec.New("helper", spec.Report(report.Terminal{}))
+	suite("Properties", testProperties)
+	suite.Run(t)
 }

--- a/helper/properties.go
+++ b/helper/properties.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package helper
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/buildpacks/libcnb"
+	"github.com/paketo-buildpacks/libpak/bard"
+	"github.com/paketo-buildpacks/libpak/bindings"
+)
+
+type Properties struct {
+	Bindings libcnb.Bindings
+	Logger   bard.Logger
+}
+
+func (p Properties) Execute() (map[string]string, error) {
+	b, ok, err := bindings.ResolveOne(p.Bindings, bindings.OfType("opentelemetry"))
+	if err != nil {
+		return nil, fmt.Errorf("unable to resolve binding opentelemetry\n%w", err)
+	} else if !ok {
+		return nil, nil
+	}
+
+	p.Logger.Info("Configuring OpenTelemetry Agent properties")
+
+	/*
+	 * Properties are expected to be passed via a configtree format,
+	 * where each key is the name of a file and the value its content.
+	 */
+	e := make(map[string]string, len(b.Secret))
+	for k, v := range b.Secret {
+		s := strings.ToUpper(k)
+		s = strings.ReplaceAll(s, "-", "_")
+		s = strings.ReplaceAll(s, ".", "_")
+
+		e[s] = v
+	}
+
+	return e, nil
+}

--- a/helper/properties_test.go
+++ b/helper/properties_test.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package helper_test
+
+import (
+	"testing"
+
+	"github.com/buildpacks/libcnb"
+	. "github.com/onsi/gomega"
+	"github.com/sclevine/spec"
+
+	"github.com/paketo-buildpacks/opentelemetry/helper"
+)
+
+func testProperties(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		p helper.Properties
+	)
+
+	it("does not contribute properties if no binding exists", func() {
+		Expect(p.Execute()).To(BeNil())
+	})
+
+	it("contributes properties if binding exists as a config tree", func() {
+		p.Bindings = libcnb.Bindings{
+			{
+				Name: "test-binding",
+				Type: "opentelemetry",
+				Secret: map[string]string{
+					"otel.test.my-key":            "test-value",
+					"otel.testagain.my-other-key": "other test value",
+				},
+			},
+		}
+
+		Expect(p.Execute()).To(Equal(map[string]string{
+			"OTEL_TEST_MY_KEY":            "test-value",
+			"OTEL_TESTAGAIN_MY_OTHER_KEY": "other test value",
+		}))
+	})
+}

--- a/opentelemetry/build.go
+++ b/opentelemetry/build.go
@@ -48,13 +48,21 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	if _, ok, err := pr.Resolve("opentelemetry-java"); err != nil {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to resolve opentelemetry-java plan entry\n%w", err)
 	} else if ok {
-		agentDependency, err := dr.Resolve("opentelemetry-java", "")
+		dep, err := dr.Resolve("opentelemetry-java", "")
 		if err != nil {
 			return libcnb.BuildResult{}, fmt.Errorf("unable to find dependency\n%w", err)
 		}
 
-		result.Layers = append(result.Layers, NewJavaAgent(agentDependency, dc, b.Logger))
+		ja, be := NewJavaAgent(context.Buildpack.Path, dep, dc)
+		ja.Logger = b.Logger
+		result.Layers = append(result.Layers, ja)
+		result.BOM.Entries = append(result.BOM.Entries, be)
 	}
+
+	h, be := libpak.NewHelperLayer(context.Buildpack, "properties")
+	h.Logger = b.Logger
+	result.Layers = append(result.Layers, h)
+	result.BOM.Entries = append(result.BOM.Entries, be)
 
 	return result, nil
 }

--- a/opentelemetry/build_test.go
+++ b/opentelemetry/build_test.go
@@ -23,7 +23,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/sclevine/spec"
 
-	"github.com/ThomasVitale/buildpacks-opentelemetry/opentelemetry"
+	"github.com/paketo-buildpacks/libpak"
+	"github.com/paketo-buildpacks/opentelemetry/opentelemetry"
 )
 
 func testBuild(t *testing.T, context spec.G, it spec.S) {
@@ -39,7 +40,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			"dependencies": []map[string]interface{}{
 				{
 					"id":      "opentelemetry-java",
-					"version": "1.15.0",
+					"version": "1.18.0",
 					"stacks":  []interface{}{"test-stack-id"},
 				},
 			},
@@ -50,8 +51,14 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		result, err := opentelemetry.Build{}.Build(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(result.Layers).To(HaveLen(1))
+		Expect(result.Layers).To(HaveLen(2))
 		Expect(result.Layers[0].Name()).To(Equal("opentelemetry-java"))
+		Expect(result.Layers[1].Name()).To(Equal("helper"))
+		Expect(result.Layers[1].(libpak.HelperLayerContributor).Names).To(Equal([]string{"properties"}))
+
+		Expect(result.BOM.Entries).To(HaveLen(2))
+		Expect(result.BOM.Entries[0].Name).To(Equal("opentelemetry-java"))
+		Expect(result.BOM.Entries[1].Name).To(Equal("helper"))
 	})
 
 	it("contributes Java agent API >= 0.7", func() {
@@ -60,10 +67,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			"dependencies": []map[string]interface{}{
 				{
 					"id":      "opentelemetry-java",
-					"version": "1.15.0",
+					"version": "1.18.0",
 					"stacks":  []interface{}{"test-stack-id"},
-					"cpes":    []interface{}{"cpe:2.3:a:open-telemetry:opentelemetry-java-agent:1.15.0:*:*:*:*:*:*:*"},
-					"purl":    "pkg:generic/opentelemetry-java@1.15.0",
+					"cpes":    []interface{}{"cpe:2.3:a:open-telemetry:opentelemetry-java-agent:1.18.0:*:*:*:*:*:*:*"},
+					"purl":    "pkg:generic/opentelemetry-java@1.18.0",
 				},
 			},
 		}
@@ -73,8 +80,14 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		result, err := opentelemetry.Build{}.Build(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(result.Layers).To(HaveLen(1))
+		Expect(result.Layers).To(HaveLen(2))
 		Expect(result.Layers[0].Name()).To(Equal("opentelemetry-java"))
+		Expect(result.Layers[1].Name()).To(Equal("helper"))
+		Expect(result.Layers[1].(libpak.HelperLayerContributor).Names).To(Equal([]string{"properties"}))
+
+		Expect(result.BOM.Entries).To(HaveLen(2))
+		Expect(result.BOM.Entries[0].Name).To(Equal("opentelemetry-java"))
+		Expect(result.BOM.Entries[1].Name).To(Equal("helper"))
 	})
 
 }

--- a/opentelemetry/detect_test.go
+++ b/opentelemetry/detect_test.go
@@ -20,9 +20,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ThomasVitale/buildpacks-opentelemetry/opentelemetry"
 	"github.com/buildpacks/libcnb"
 	. "github.com/onsi/gomega"
+	"github.com/paketo-buildpacks/opentelemetry/opentelemetry"
 	"github.com/sclevine/spec"
 )
 

--- a/opentelemetry/java_agent.go
+++ b/opentelemetry/java_agent.go
@@ -28,7 +28,6 @@ import (
 )
 
 type JavaAgent struct {
-	BuildpackPath    string
 	LayerContributor libpak.DependencyLayerContributor
 	Logger           bard.Logger
 }
@@ -38,7 +37,6 @@ func NewJavaAgent(buildpackPath string, dependency libpak.BuildpackDependency, c
 		Launch: true,
 	})
 	return JavaAgent{
-		BuildpackPath:    buildpackPath,
 		LayerContributor: contributor,
 	}, entry
 }

--- a/opentelemetry/java_agent_test.go
+++ b/opentelemetry/java_agent_test.go
@@ -18,17 +18,15 @@ package opentelemetry_test
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/ThomasVitale/buildpacks-opentelemetry/opentelemetry"
 	"github.com/buildpacks/libcnb"
 	. "github.com/onsi/gomega"
 	"github.com/paketo-buildpacks/libpak"
-	"github.com/paketo-buildpacks/libpak/bard"
+	"github.com/paketo-buildpacks/opentelemetry/opentelemetry"
 	"github.com/sclevine/spec"
 )
 
@@ -62,8 +60,7 @@ func testJavaAgent(t *testing.T, context spec.G, it spec.S) {
 		}
 		dc := libpak.DependencyCache{CachePath: "testdata"}
 
-		j := opentelemetry.NewJavaAgent(dep, dc, bard.NewLogger(io.Discard))
-
+		j, _ := opentelemetry.NewJavaAgent(ctx.Buildpack.Path, dep, dc)
 		layer, err := ctx.Layers.Layer("test-layer")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -75,5 +72,7 @@ func testJavaAgent(t *testing.T, context spec.G, it spec.S) {
 		Expect(layer.LaunchEnvironment["JAVA_TOOL_OPTIONS.delim"]).To(Equal(" "))
 		Expect(layer.LaunchEnvironment["JAVA_TOOL_OPTIONS.append"]).To(Equal(fmt.Sprintf("-javaagent:%s",
 			filepath.Join(layer.Path, "stub-opentelemetry-java-agent.jar"))))
+		Expect(layer.LaunchEnvironment["OTEL_JAVAAGENT_ENABLED.default"]).To(Equal("false"))
+		Expect(layer.LaunchEnvironment["OTEL_METRICS_EXPORTER.default"]).To(Equal("none"))
 	})
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,14 +2,15 @@
 
 set -euo pipefail
 
-GOOS="linux" go build -ldflags='-s -w' -o bin/main github.com/ThomasVitale/buildpacks-opentelemetry/cmd/main
+GOOS="linux" go build -ldflags='-s -w' -o bin/helper github.com/paketo-buildpacks/opentelemetry/cmd/helper
+GOOS="linux" go build -ldflags='-s -w' -o bin/main github.com/paketo-buildpacks/opentelemetry/cmd/main
 
 if [ "${STRIP:-false}" != "false" ]; then
-  strip bin/main
+  strip bin/helper bin/main
 fi
 
 if [ "${COMPRESS:-none}" != "none" ]; then
-  $COMPRESS bin/main
+  $COMPRESS bin/helper bin/main
 fi
 
 ln -fs main bin/build


### PR DESCRIPTION
## Summary

* Add possibility to configure the OpenTelemetry Agent via a binding.
* Move Go module namespace from my personal GitHub to Paketo.
* Update documentation with more information about the default configuration and how to customise it via environment variables or dedicated binding.

## Use Cases

* When configuring the OpenTelemetry Agent, we might need to pass sensitive data like the credentials to access an OTel backend (such as Grafana Tempo). In that case, passing the configuration via a binding reduces the risk to expose the sensitive data compared to using plain environment variables.

## Test

In this [separate branch](https://github.com/paketo-buildpacks/opentelemetry/compare/support-config-via-binding...test-app-config), I have added a demo app and documentation to test and validate the Buildpack. I haven't included that in this PR since the sample app will eventually be included in https://github.com/paketo-buildpacks/samples once we cut the first release.

## Checklist
<!-- Please confirm the following -->
* [x ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
