### PR TITLE
Add missing file to buildpack packages

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -14,7 +14,7 @@ api = "0.7"
     uri = "https://github.com/paketo-buildpacks/opentelemetry/blob/main/LICENSE"
 
 [metadata]
-  include-files = ["LICENSE", "NOTICE", "README.md", "bin/build", "bin/detect", "bin/main", "buildpack.toml"]
+  include-files = ["LICENSE", "NOTICE", "README.md", "bin/build", "bin/detect", "bin/main", "bin/helper", "buildpack.toml"]
   pre-package = "scripts/build.sh"
 
   [[metadata.configurations]]


### PR DESCRIPTION
## Summary

The 'bin/helper' was not included in the list of files to include with the buildpack. This adds it.

## Use Cases

Resolves #31 
