### PR TITLE
Update OpenTelemetry Java Agent to 2.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ At build time, the buildpack will do the following for Java applications:
 
 * Contributes the OpenTelemetry Java agent to a layer and configures `$JAVA_TOOL_OPTIONS` to use it.
 * By default, the agent is configured to be disabled (`OTEL_JAVAAGENT_ENABLED=false`).
+* By default, the logs exporting feature of the agent is configured to be disabled (`OTEL_LOGS_EXPORTER=none`).
 * By default, the metrics exporting feature of the agent is configured to be disabled (`OTEL_METRICS_EXPORTER=none`).
 
 At run time, the buildpack will do the following for Java applications:
@@ -27,6 +28,7 @@ Once you enable the OpenTelemetry buildpack at build-time, you can configure it 
 By default, the following configuration is applied to the OpenTelemetry Java Agent at run time.
 
 * `OTEL_JAVAAGENT_ENABLED=false`
+* `OTEL_LOGS_EXPORTER=none`
 * `OTEL_METRICS_EXPORTER=none`
 
 When using a [binding](https://paketo.io/docs/howto/configuration/#bindings), key/values map directly to OpenTelemetry Java agent configuration properties. Keys can follow the environment variable format or the system property format, as described in the [project documentation](https://opentelemetry.io/docs/instrumentation/java/automatic/agent-config/).

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -38,16 +38,16 @@ api = "0.7"
     name = "BP_OPENTELEMETRY_ENABLED"
 
   [[metadata.dependencies]]
-    cpes = ["cpe:2.3:a:open-telemetry:opentelemetry-java-agent:1.32.0:*:*:*:*:*:*:*"]
+    cpes = ["cpe:2.3:a:open-telemetry:opentelemetry-java-agent:2.4.0:*:*:*:*:*:*:*"]
     id = "opentelemetry-java"
     name = "OpenTelemetry Java Agent"
-    purl = "pkg:generic/opentelemetry-java@1.32.0"
-    sha256 = "2a2af4c5e57de5e6f688b9921df5dda5cda4eda9626ee5f34ddc5852f84c45d0"
-    source = "https://github.com/open-telemetry/opentelemetry-java-instrumentation/archive/refs/tags/v1.32.0.tar.gz"
-    source-sha256 = "aee96dfc00b58847d247ee38e221c637ca2d69f3b7644f7c06b6b6fb275f86c2"
+    purl = "pkg:generic/opentelemetry-java@2.4.0"
+    sha256 = "99a3bbd05d2ee93bcbd169de7814fa46c9dfdea61661deb806c09d0e1c288a85"
+    source = "https://github.com/open-telemetry/opentelemetry-java-instrumentation/archive/refs/tags/v2.4.0.tar.gz"
+    source-sha256 = "1d3446e64538f3af0f78ff8c09481c2c52e5619e3bd7845aed92939cc9035933"
     stacks = ["*"]
-    uri = "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.32.0/opentelemetry-javaagent.jar"
-    version = "1.32.0"
+    uri = "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.4.0/opentelemetry-javaagent.jar"
+    version = "2.4.0"
 
     [[metadata.dependencies.licenses]]
       type = "Apache-2.0"

--- a/opentelemetry/java_agent.go
+++ b/opentelemetry/java_agent.go
@@ -54,6 +54,7 @@ func (j JavaAgent) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 
 		layer.LaunchEnvironment.Appendf("JAVA_TOOL_OPTIONS", " ", "-javaagent:%s", file)
 		layer.LaunchEnvironment.Default("OTEL_JAVAAGENT_ENABLED", "false")
+		layer.LaunchEnvironment.Default("OTEL_LOGS_EXPORTER", "none")
 		layer.LaunchEnvironment.Default("OTEL_METRICS_EXPORTER", "none")
 
 		return layer, nil

--- a/opentelemetry/java_agent_test.go
+++ b/opentelemetry/java_agent_test.go
@@ -73,6 +73,7 @@ func testJavaAgent(t *testing.T, context spec.G, it spec.S) {
 		Expect(layer.LaunchEnvironment["JAVA_TOOL_OPTIONS.append"]).To(Equal(fmt.Sprintf("-javaagent:%s",
 			filepath.Join(layer.Path, "stub-opentelemetry-java-agent.jar"))))
 		Expect(layer.LaunchEnvironment["OTEL_JAVAAGENT_ENABLED.default"]).To(Equal("false"))
+		Expect(layer.LaunchEnvironment["OTEL_LOGS_EXPORTER.default"]).To(Equal("none"))
 		Expect(layer.LaunchEnvironment["OTEL_METRICS_EXPORTER.default"]).To(Equal("none"))
 	})
 }


### PR DESCRIPTION
## Summary

Bump opentelemetry-java from 1.32.0 to 2.4.0

Fixes gh-113

## Release Notes

OpenTelemetry Java 2.0.0 introduced breaking changes. You can find more details [here](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.0.0). Make sure to check them before upgrading to this new version of the OpenTelemetry Buildpack.

## Checklist

* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
